### PR TITLE
Overload WeightBySelection() to allow to take weights from tree inste…

### DIFF
--- a/HaSpect/THSWeights.h
+++ b/HaSpect/THSWeights.h
@@ -78,6 +78,7 @@ class THSWeights : public TNamed{
   void Save();
   void LoadSaved(TString fname,TString wname);
   void WeightBySelection(TTree* tree,TCut cut,Double_t wgt);
+  void WeightBySelection(TTree* tree,TCut cut,TString wgt);
   
   ClassDef(THSWeights, 3)  // Writeble Weight map  class
 };


### PR DESCRIPTION
…ad of a fixed value. This is particularly useful if one creates weights during a previous analysis step in a Selector class. E.g. having multiple combos after applying cuts could be treated with a 1/(Ncombos) weight.